### PR TITLE
shutil.move instead of os.rename

### DIFF
--- a/send2trash/plat_other.py
+++ b/send2trash/plat_other.py
@@ -22,6 +22,7 @@ import os
 import os.path as op
 from datetime import datetime
 import stat
+import shutil
 try:
     from urllib.parse import quote
 except ImportError:
@@ -100,7 +101,7 @@ def trash_move(src, dst, topdir=None):
     check_create(filespath)
     check_create(infopath)
 
-    os.rename(src, op.join(filespath, destname))
+    shutil.move(src, op.join(filespath, destname))
     f = open(op.join(infopath, destname + INFO_SUFFIX), 'w')
     f.write(info_for(src, topdir))
     f.close()


### PR DESCRIPTION
when sending a file which is mounted from a different device to trash, `os.rename` will produce:
`OSError: [Errno 18] Invalid cross-device link`

Switching to shutil.move will solve this.