### PR TITLE
Update plat_other.py

### DIFF
--- a/send2trash/plat_other.py
+++ b/send2trash/plat_other.py
@@ -110,11 +110,11 @@ def trash_move(src, dst, topdir=None):
 
     check_create(filespath)
     check_create(infopath)
-
-    os.rename(src, op.join(filespath, destname))
+    
     f = open(op.join(infopath, destname + INFO_SUFFIX), "w")
     f.write(info_for(src, topdir))
     f.close()
+    os.rename(src, op.join(filespath, destname))
 
 
 def find_mount_point(path):


### PR DESCRIPTION
The trash info file needs to exist before the file is moved into the trash folder. 
This is to conform to the events based detection of trashed files in gnome and other file managers.