### PR TITLE
Adding power support for this package to support arch independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,16 @@ matrix:
     # Obtain Python 3.7 from xenial as per https://github.com/travis-ci/travis-ci/issues/9815
     - python: "3.7"
       dist: xenial
+
+    - python: "2.7"
+      arch: ppc64le
+    - python: "3.6"
+      arch: ppc64le
+    # Obtain Python 3.7 from xenial as per https://github.com/travis-ci/travis-ci/issues/9815
+    - python: "3.7"
+      dist: xenial
+    - python: "3.8"
+      dist: bionic
 install:
   - pip install tox
 before_script:


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro 
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.

This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model.

Please help to verify and merge.

