### PR TITLE
Fix Windows compatibility with multithreading

### DIFF
--- a/send2trash/plat_win_modern.py
+++ b/send2trash/plat_win_modern.py
@@ -13,6 +13,8 @@ import pywintypes
 from win32com.shell import shell, shellcon
 from .IFileOperationProgressSink import CreateSink
 
+pythoncom.CoInitialize()
+
 
 def send2trash(paths):
     if not isinstance(paths, list):


### PR DESCRIPTION
Hi.

I've faced with some tests of [Jupyterhub Notebook](https://github.com/jupyter/notebook/runs/3061632134) repo are failing:
```
Traceback (most recent call last):
  File "c:\hostedtoolcache\windows\python\3.6.8\x64\lib\site-packages\tornado\web.py", line 1704, in _execute
    result = await result
  File "c:\hostedtoolcache\windows\python\3.6.8\x64\lib\site-packages\tornado\gen.py", line 234, in wrapper
    yielded = ctx_run(next, result)
  File "c:\hostedtoolcache\windows\python\3.6.8\x64\lib\site-packages\tornado\gen.py", line 162, in _fake_ctx_run
    return f(*args, **kw)
  File "D:\a\notebook\notebook\notebook\services\contents\handlers.py", line 237, in delete
    yield maybe_future(cm.delete(path))
  File "D:\a\notebook\notebook\notebook\services\contents\manager.py", line 279, in delete
    self.delete_file(path)
  File "D:\a\notebook\notebook\notebook\services\contents\filemanager.py", line 533, in delete_file
    send2trash(os_path)
  File "c:\hostedtoolcache\windows\python\3.6.8\x64\lib\site-packages\send2trash\plat_win_modern.py", line 31, in send2trash
    shell.CLSID_FileOperation, None, pythoncom.CLSCTX_ALL, shell.IID_IFileOperation,
pywintypes.com_error: (-2147221008, 'CoInitialize has not been called.', None, None)
```

According to https://stackoverflow.com/questions/37258257/why-does-this-script-not-work-with-threading-python, it is important to call `.CoInitialize()` method to allow win32 API calls in multithread mode.