### PR TITLE
fix trash_move

### DIFF
--- a/send2trash/plat_other.py
+++ b/send2trash/plat_other.py
@@ -112,7 +112,8 @@ def trash_move(src, dst, topdir=None):
 
     with open(op.join(infopath, destname + INFO_SUFFIX), "w") as f:
         f.write(info_for(src, topdir))
-    os.rename(src, op.join(filespath, destname))
+    shutil.copy(src, op.join(filespath, destname))
+    os.remove(src)
 
 
 def find_mount_point(path):

--- a/send2trash/plat_other.py
+++ b/send2trash/plat_other.py
@@ -24,7 +24,6 @@ from datetime import datetime
 import shutil
 import stat
 
-
 try:
     from urllib.parse import quote
 except ImportError:

--- a/send2trash/plat_other.py
+++ b/send2trash/plat_other.py
@@ -21,7 +21,9 @@ import sys
 import os
 import os.path as op
 from datetime import datetime
+import shutil
 import stat
+
 
 try:
     from urllib.parse import quote


### PR DESCRIPTION
the same as https://github.com/arsenetar/send2trash/pull/41

this bug prevents using jupyter* in research environments where file systems aren't always local

e.g. https://github.com/jupyterlab/jupyterlab/issues/5781 and our own use at https://cri.uchicago.edu/

cc @annawoodard