### PR TITLE
Support for any iterable type as input data

### DIFF
--- a/send2trash/compat.py
+++ b/send2trash/compat.py
@@ -18,3 +18,8 @@ else:
     text_type = unicode  # noqa: F821
     binary_type = str
     environb = os.environ
+
+try:
+    from collections.abc import Iterable as iterable_type
+except ImportError:
+    from collections import Iterable as iterable_type

--- a/send2trash/util.py
+++ b/send2trash/util.py
@@ -5,9 +5,13 @@
 # which should be included with this package. The terms are also available at
 # http://www.hardcoded.net/licenses/bsd_license
 
+from send2trash.compat import text_type, binary_type, iterable_type
+
 
 def preprocess_paths(paths):
-    if not isinstance(paths, list):
+    if isinstance(paths, iterable_type) and not isinstance(paths, (text_type, binary_type)):
+        paths = list(paths)
+    elif not isinstance(paths, list):
         paths = [paths]
     # Convert items such as pathlib paths to strings
     paths = [path.__fspath__() if hasattr(path, "__fspath__") else path for path in paths]


### PR DESCRIPTION
For now the function accepts only path object or list as input. This pool request adds support for any iterable type such as tuple or generator.