### PR TITLE
Wndows: fail if not recyclable

### DIFF
--- a/send2trash/win/IFileOperationProgressSink.py
+++ b/send2trash/win/IFileOperationProgressSink.py
@@ -6,6 +6,10 @@ from win32com.shell import shell, shellcon
 from win32com.server.policy import DesignatedWrapPolicy
 
 
+class E_Fail(Exception):
+    pass
+
+
 class FileOperationProgressSink(DesignatedWrapPolicy):
     _com_interfaces_ = [shell.IID_IFileOperationProgressSink]
     _public_methods_ = [
@@ -29,18 +33,30 @@ class FileOperationProgressSink(DesignatedWrapPolicy):
 
     def __init__(self):
         self._wrap_(self)
-        self.newItem = None
+        self.errors = []
 
     def PreDeleteItem(self, flags, item):
-        # Can detect cases where to stop via flags and condition below, however the operation
-        # does not actual stop, we can resort to raising an exception as that does stop things
-        # but that may need some additional considerations before implementing.
-        return 0 if flags & shellcon.TSF_DELETE_RECYCLE_IF_POSSIBLE else 0x80004005  # S_OK, or E_FAIL
+        # If TSF_DELETE_RECYCLE_IF_POSSIBLE is not set the file would not be moved to trash.
+        # Usually the code would have to return S_OK or E_FAIL to signal an abort to the file sink,
+        # however pywin32 doesn't use the return value of these callback methods [1], so we have to resort
+        # to raising an exception as that does stop things.
+        # [1] https://github.com/mhammond/pywin32/blob/1d29e4a4f317be9acbef9d5c5c5787269eacb040/com/win32com/src/PyGatewayBase.cpp#L757
+
+        name = item.GetDisplayName(shellcon.SHGDN_FORPARSING)
+        will_recycle = flags & shellcon.TSF_DELETE_RECYCLE_IF_POSSIBLE
+        if not will_recycle:
+            raise E_Fail(f"File would be deleted permanently: {name}")
+
+        return None  # HR cannot be returned here
 
     def PostDeleteItem(self, flags, item, hr_delete, newly_created):
-        if newly_created:
-            self.newItem = newly_created.GetDisplayName(shellcon.SHGDN_FORPARSING)
+        if hr_delete < 0:
+            name = item.GetDisplayName(shellcon.SHGDN_FORPARSING)
+            self.errors.append((name, hr_delete))
+
+        return None  # HR cannot be returned here
 
 
 def create_sink():
-    return pythoncom.WrapObject(FileOperationProgressSink(), shell.IID_IFileOperationProgressSink)
+    pysink = FileOperationProgressSink()
+    return pysink, pythoncom.WrapObject(pysink, shell.IID_IFileOperationProgressSink)


### PR DESCRIPTION
- Deletion can only be aborted by raising an exception. The reason for this is that pywin32 doesn't use the result of the callback functions as HR value. However since `FOFX_EARLYFAILURE` is used anyway, aborting using an exception should be fine. A unavoidable (?) log will be printed though.
```
pythoncom error: Unexpected exception in gateway method 'PreDeleteItem'

Traceback (most recent call last):
  File "...\Python38\lib\site-packages\win32com\server\policy.py", line 355, in _InvokeEx_
    return self._invokeex_(dispid, lcid, wFlags, args, kwargs, serviceProvider)
  File "...\Python38\lib\site-packages\win32com\server\policy.py", line 637, in _invokeex_
    return func(*args)
  File "...\send2trash\win\IFileOperationProgressSink.py", line 47, in PreDeleteItem
    raise E_Fail(f"File would be deleted permanently: {name}")
send2trash.win.IFileOperationProgressSink.E_Fail: File would be deleted permanently: ...\send2trash\tmp\0
```
  later the operation will raise an "unknown error" in this case (which can be caught)
```
Traceback (most recent call last):
  File "...\send2trash\win\modern.py", line 65, in send2trash
    result = fileop.PerformOperations()
pywintypes.com_error: (-2147467259, 'unknown error', None, None)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "prog.py", line 19, in <module>
    send2trash(paths)
  File "...\send2trash\win\modern.py", line 77, in send2trash
    raise win_exception(hr, path)
OSError: [WinError -2147467259] unknown error: ...\\send2trash\\tmp\\0'
```
- Error handling was slightly improved. Previously the exception would always contain the filename of the last item in the list, not the file for which the call actually failed. Also some unusual errors (at the moment only COPYENGINE_E_SHARING_VIOLATION_SRC) are converted to standard exceptions (in this case a PermissionError)