### PR TITLE
Fix bug when source and destination directories are on different file systems

### DIFF
--- a/send2trash/plat_other.py
+++ b/send2trash/plat_other.py
@@ -115,7 +115,7 @@ def trash_move(src, dst, topdir=None, cross_dev=False):
         f.write(info_for(src, topdir))
     destpath = op.join(filespath, destname)
     if cross_dev:
-        shutil.move(src, destpath)
+        shutil.move(fsdecode(src), fsdecode(destpath))
     else:
         os.rename(src, destpath)
 


### PR DESCRIPTION
`shutil.move()` function expects string paths, not byte paths. This bug is leading to failure in our production environment because our src and dest are on the different file system.