### PR TITLE
chore: Upgrade version to 1.8.3, bump CI

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -46,7 +46,7 @@ jobs:
             python-version: 2.7
           # - os: macos-latest
           #   python-version: 3.11
-          # - os: macos-latest
+          # - os: macos-latestgit push
           #   python-version: 3.8
           # - os: macos-latest
           #   python-version: 2.7
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: LizardByte/setup-python-action@master
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,9 +12,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.x
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install dependencies
@@ -31,6 +31,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            python-version: 3.12
+          - os: ubuntu-latest
             python-version: 3.11
           - os: ubuntu-latest
             python-version: "3.10"
@@ -40,10 +42,6 @@ jobs:
             python-version: 3.8
           - os: ubuntu-latest
             python-version: 3.7
-          - os: ubuntu-20.04
-            python-version: 3.6
-          - os: ubuntu-20.04
-            python-version: 3.5
           - os: ubuntu-latest
             python-version: 2.7
           # - os: macos-latest
@@ -53,16 +51,16 @@ jobs:
           # - os: macos-latest
           #   python-version: 2.7
           - os: windows-latest
-            python-version: 3.11
+            python-version: 3.12
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
             python-version: 2.7
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 1.8.3 -- 2024/04/06
+---------------------------
+* Add support for any iterable type as input by @PalmtopTiger in https://github.com/arsenetar/send2trash/pull/88
+* fix: Use os.fsdecode() for arguments to shutil.move() by @yogeshiitm in https://github.com/arsenetar/send2trash/pull/90
+
 Version 1.8.2 -- 2023/04/27
 ---------------------------
 * win/legacy: tiny logic simplification by @BoboTiG in https://github.com/arsenetar/send2trash/pull/77

--- a/send2trash/compat.py
+++ b/send2trash/compat.py
@@ -22,4 +22,4 @@ else:
 try:
     from collections.abc import Iterable as iterable_type
 except ImportError:
-    from collections import Iterable as iterable_type
+    from collections import Iterable as iterable_type  # noqa: F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Send2Trash
-version = 1.8.2
+version = 1.8.3
 url = https://github.com/arsenetar/send2trash
 project_urls = 
     Bug Reports = https://github.com/arsenetar/send2trash/issues
@@ -20,19 +20,18 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Desktop Environment :: File Managers
 
 [options]
 packages = find:
 tests_require = pytest
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*
 
 [options.packages.find]
 include=


### PR DESCRIPTION
- Upgrade version to 1.8.3, add changelog entry
- Fix minor flake8 error that can be ignored
- Update CI workflow to use newer actions and python versions