### PR TITLE
ci: migrate LizardByte/setup-python-action

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: LizardByte/setup-python-action@master
+        uses: LizardByte/actions/actions/setup_python@master
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
LizardByte/setup-python-action is deprecated and has moved to LizardByte/actions.