### PR TITLE
Update source installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,21 +32,21 @@ To install with pywin32 or pyobjc required specify the extra `nativeLib`:
 
 or download the source from https://github.com/arsenetar/send2trash and install it with:
 
-    >>> python -m pip install -e .
+    python -m pip install -e .
 
 On systems where Python enforces PEP 668 (e.g., recent Linux distributions),
 installing packages into the system Python may be restricted.
 Use a virtual environment:
 
-    >>> python -m venv .venv
+    python -m venv .venv
 
     GNU/Linux / macOS:
 
-        >>> source .venv/bin/activate
+        source .venv/bin/activate
 
     Windows:
 
-        >>> .venv\Scripts\activate
+        .venv\Scripts\activate
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,23 @@ To install with pywin32 or pyobjc required specify the extra `nativeLib`:
 
     python -m pip install -U send2trash[nativeLib]
 
-or you can download the source from http://github.com/arsenetar/send2trash and install it with::
+or download the source from https://github.com/arsenetar/send2trash and install it with:
 
-    >>> python setup.py install
+    >>> python -m pip install -e .
+
+On systems where Python enforces PEP 668 (e.g., recent Linux distributions),
+installing packages into the system Python may be restricted.
+Use a virtual environment:
+
+    >>> python -m venv .venv
+
+    GNU/Linux / macOS:
+
+        >>> source .venv/bin/activate
+
+    Windows:
+
+        >>> .venv\Scripts\activate
 
 Usage
 -----


### PR DESCRIPTION
- Replace non-working python setup.py install (no setup.py in repo) with python -m pip install -e .
- Add virtual environment setup to work around PEP 668 restrictions (e.g. on Linux Mint 22.1)
- Update GitHub URL to HTTPS