### PR TITLE
python2 removal: more clean up

### DIFF
--- a/send2trash/__main__.py
+++ b/send2trash/__main__.py
@@ -1,11 +1,8 @@
-# encoding: utf-8
 # Copyright 2017 Virgil Dupras
 
 # This software is licensed under the "BSD" License as described in the "LICENSE" file,
 # which should be included with this package. The terms are also available at
 # http://www.hardcoded.net/licenses/bsd_license
-
-from __future__ import print_function
 
 import sys
 

--- a/send2trash/mac/legacy.py
+++ b/send2trash/mac/legacy.py
@@ -4,7 +4,6 @@
 # which should be included with this package. The terms are also available at
 # http://www.hardcoded.net/licenses/bsd_license
 
-from __future__ import unicode_literals
 
 from ctypes import cdll, byref, Structure, c_char, c_char_p
 from ctypes.util import find_library

--- a/send2trash/plat_other.py
+++ b/send2trash/plat_other.py
@@ -14,7 +14,6 @@
 # For external volumes this implementation will raise an exception if it can't
 # find or create the user's trash directory.
 
-from __future__ import unicode_literals
 
 import errno
 import shutil

--- a/send2trash/util.py
+++ b/send2trash/util.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # Copyright 2017 Virgil Dupras
 
 # This software is licensed under the "BSD" License as described in the "LICENSE" file,

--- a/send2trash/win/__init__.py
+++ b/send2trash/win/__init__.py
@@ -4,7 +4,6 @@
 # which should be included with this package. The terms are also available at
 # http://www.hardcoded.net/licenses/bsd_license
 
-from __future__ import unicode_literals
 from platform import version
 
 # if windows is vista or newer and pywin32 is available use IFileOperation

--- a/send2trash/win/legacy.py
+++ b/send2trash/win/legacy.py
@@ -4,7 +4,6 @@
 # which should be included with this package. The terms are also available at
 # http://www.hardcoded.net/licenses/bsd_license
 
-from __future__ import unicode_literals
 import os.path as op
 from ctypes import (
     windll,

--- a/send2trash/win/modern.py
+++ b/send2trash/win/modern.py
@@ -4,7 +4,6 @@
 # which should be included with this package. The terms are also available at
 # http://www.hardcoded.net/licenses/bsd_license
 
-from __future__ import unicode_literals
 import os.path as op
 from platform import version
 import pythoncom

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 import sys
 import os
 from tempfile import NamedTemporaryFile

--- a/tests/test_plat_other.py
+++ b/tests/test_plat_other.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 import codecs
 import os
 import sys

--- a/tests/test_plat_win.py
+++ b/tests/test_plat_win.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 import os
 import shutil
 import sys

--- a/tests/test_script_main.py
+++ b/tests/test_script_main.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 from os import path as op
 import pytest
 


### PR DESCRIPTION
1. remove from __future__ as those feature is mandatory >= 3.0 and we are in the future
2. python3 script defaults to UTF-8