### PR TITLE
Backend: add KIO backend for KDE platforms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,11 @@ Send2Trash -- Send files to trash on all platforms
 ==================================================
 
 Send2Trash is a small package that sends files to the Trash (or Recycle Bin) *natively* and on
-*all platforms*. On OS X, it uses native ``FSMoveObjectToTrashSync`` Cocoa calls or can use pyobjc 
-with NSFileManager. On Windows, it uses native ``IFileOperation`` call if on Vista or newer and 
-pywin32 is installed or falls back to ``SHFileOperation`` calls. On other platforms, if `PyGObject`_ 
-and `GIO`_ are available, it will use this.  Otherwise, it will fallback to its own implementation of 
+*all platforms*. On OS X, it uses native ``FSMoveObjectToTrashSync`` Cocoa calls or can use pyobjc
+with NSFileManager. On Windows, it uses native ``IFileOperation`` call if on Vista or newer and
+pywin32 is installed or falls back to ``SHFileOperation`` calls. On KDE desktops, if ``kioclient``
+is available, it will use the native KIO trash implementation. On other platforms, if `PyGObject`_
+and `GIO`_ are available, it will use this. Otherwise, it will fallback to its own implementation of
 the `trash specifications from freedesktop.org`_.
 
 ``ctypes`` is used to access native libraries, so no compilation is necessary.

--- a/send2trash/__init__.py
+++ b/send2trash/__init__.py
@@ -16,9 +16,21 @@ if sys.platform == "darwin":
 elif sys.platform == "win32":
     from send2trash.win import send2trash
 else:
+    send2trash = None
     try:
-        # If we can use gio, let's use it
-        from send2trash.plat_gio import send2trash
+        from send2trash.plat_kio import is_available as _kio_is_available
+        from send2trash.plat_kio import send2trash as _send2trash
     except ImportError:
-        # Oh well, let's fallback to our own Freedesktop trash implementation
-        from send2trash.plat_other import send2trash  # noqa: F401
+        _send2trash = None
+    else:
+        if _kio_is_available():
+            send2trash = _send2trash
+
+    if send2trash is None:
+        try:
+            # If we can use gio, let's use it
+            from send2trash.plat_gio import send2trash as _send2trash
+        except ImportError:
+            # Oh well, let's fallback to our own Freedesktop trash implementation
+            from send2trash.plat_other import send2trash as _send2trash  # noqa: F401
+        send2trash = _send2trash

--- a/send2trash/plat_kio.py
+++ b/send2trash/plat_kio.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Hardcoded Software (http://www.hardcoded.net)
+
+# This software is licensed under the "BSD" License as described in the "LICENSE" file,
+# which should be included with this package. The terms are also available at
+# http://www.hardcoded.net/licenses/bsd_license
+
+import os
+import shutil
+import subprocess
+from functools import lru_cache
+from urllib.parse import quote
+
+from send2trash.util import preprocess_paths
+
+
+@lru_cache(maxsize=1)
+def _kioclient():
+    for name in ("kioclient6", "kioclient5", "kioclient"):
+        command = shutil.which(name)
+        if command is not None:
+            return command
+    raise ImportError("No kioclient executable found")
+
+
+def _is_kde_session():
+    if os.environ.get("KDE_FULL_SESSION", "").lower() == "true":
+        return True
+
+    desktop_values = " ".join(
+        os.environ.get(name, "") for name in (
+            "XDG_CURRENT_DESKTOP", 
+            "XDG_SESSION_DESKTOP", 
+            "DESKTOP_SESSION"
+        )
+    ).lower()
+    return "kde" in desktop_values or "plasma" in desktop_values
+
+
+def _path_to_url(path):
+    # KIO expects local file URLs rather than raw filesystem paths.
+    return "file://" + quote(os.path.abspath(os.fsdecode(path)))
+
+
+def is_available():
+    if not _is_kde_session():
+        return False
+
+    try:
+        command = _kioclient()
+    except ImportError:
+        return False
+
+    try:
+        result = subprocess.run(
+            [
+                command, "stat", "trash:/"
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+            check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def send2trash(paths):
+    paths = preprocess_paths(paths)
+    command = [_kioclient(), "move", *(_path_to_url(path) for path in paths), "trash:/"]
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as error:
+        message = error.stderr.strip() \
+            or error.stdout.strip() \
+            or f"{command[0]} exited with status {error.returncode}"
+        raise OSError(message) from error

--- a/tests/test_plat_kio.py
+++ b/tests/test_plat_kio.py
@@ -1,0 +1,109 @@
+import subprocess
+
+import pytest
+
+import send2trash.plat_kio as plat_kio
+
+
+def test_kioclient_prefers_newest_available(monkeypatch):
+    def fake_which(name):
+        return {
+            "kioclient6": None,
+            "kioclient5": "/usr/bin/kioclient5",
+            "kioclient": "/usr/bin/kioclient",
+        }[name]
+
+    monkeypatch.setattr(plat_kio.shutil, "which", fake_which)
+    assert plat_kio._kioclient() == "/usr/bin/kioclient5"
+
+
+def test_is_kde_session_detects_kde_env(monkeypatch):
+    monkeypatch.setattr(
+        plat_kio.os,
+        "environ",
+        {
+            "KDE_FULL_SESSION": "true",
+        },
+        raising=False,
+    )
+    assert plat_kio._is_kde_session() is True
+
+
+def test_is_kde_session_rejects_non_kde_env(monkeypatch):
+    monkeypatch.setattr(
+        plat_kio.os,
+        "environ",
+        {
+            "XDG_CURRENT_DESKTOP": "GNOME",
+            "XDG_SESSION_DESKTOP": "",
+            "DESKTOP_SESSION": "",
+        },
+        raising=False,
+    )
+    assert plat_kio._is_kde_session() is False
+
+
+def test_send2trash_builds_kio_move_command(monkeypatch):
+    calls = {}
+
+    def fake_which(name):
+        return "/usr/bin/kioclient5" if name == "kioclient5" else None
+
+    def fake_run(command, check, capture_output, text):
+        calls["command"] = command
+        calls["check"] = check
+        calls["capture_output"] = capture_output
+        calls["text"] = text
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(plat_kio.shutil, "which", fake_which)
+    monkeypatch.setattr(plat_kio.subprocess, "run", fake_run)
+
+    plat_kio.send2trash(["/tmp/send2trash test.txt"])
+
+    assert calls["command"] == [
+        "/usr/bin/kioclient5",
+        "move",
+        "file:///tmp/send2trash%20test.txt",
+        "trash:/",
+    ]
+    assert calls["check"] is True
+    assert calls["capture_output"] is True
+    assert calls["text"] is True
+
+
+def test_is_available_returns_false_outside_kde(monkeypatch):
+    monkeypatch.setattr(plat_kio, "_is_kde_session", lambda: False)
+    assert plat_kio.is_available() is False
+
+
+def test_send2trash_raises_oserror_on_kio_failure(monkeypatch):
+    def fake_which(name):
+        return "/usr/bin/kioclient5" if name == "kioclient5" else None
+
+    def fake_run(command, check, capture_output, text):
+        raise subprocess.CalledProcessError(
+            1,
+            command,
+            output="",
+            stderr="Unable to create KIO worker",
+        )
+
+    monkeypatch.setattr(plat_kio.shutil, "which", fake_which)
+    monkeypatch.setattr(plat_kio.subprocess, "run", fake_run)
+
+    with pytest.raises(OSError, match="Unable to create KIO worker"):
+        plat_kio.send2trash(["/tmp/send2trash test.txt"])
+
+
+def test_is_available_returns_false_when_worker_probe_fails(monkeypatch):
+    def fake_which(name):
+        return "/usr/bin/kioclient5" if name == "kioclient5" else None
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 1, stdout="", stderr="")
+
+    monkeypatch.setattr(plat_kio.shutil, "which", fake_which)
+    monkeypatch.setattr(plat_kio.subprocess, "run", fake_run)
+
+    assert plat_kio.is_available() is False


### PR DESCRIPTION
Add a KDE-aware trash backend that uses kioclient/KIO on Linux when running in a KDE session and a usable KIO worker is available. KIO is more reliable when using BTRFS mounts, where GIO currently returns an error: "Trashing on system internal mounts is not supported".

Fixes #111 